### PR TITLE
Return saved answers for previously-asked questions

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
 //= link_tree ../builds

--- a/app/controllers/ask_controller.rb
+++ b/app/controllers/ask_controller.rb
@@ -3,7 +3,18 @@ class AskController < ApplicationController
 
   def create
     question = params[:question]
-    response = get_new_answer(question)
+    question_answer = QuestionAnswer.find_by(question:)
+
+    if question_answer
+      response = {
+        'message' => question_answer.answer
+      }
+    else
+      response = get_new_answer(question)
+      question_answer = QuestionAnswer.new(question:, answer: response['message'])
+      question_answer.save
+    end
+
     render json: response, status: :created
   end
 

--- a/app/models/question_answer.rb
+++ b/app/models/question_answer.rb
@@ -1,0 +1,4 @@
+class QuestionAnswer < ApplicationRecord
+  # Validations, if any
+  validates :question, :answer, presence: true
+end

--- a/db/migrate/20230709222309_create_question_answers.rb
+++ b/db/migrate/20230709222309_create_question_answers.rb
@@ -1,0 +1,10 @@
+class CreateQuestionAnswers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :question_answers do |t|
+      t.string :question
+      t.string :answer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_07_09_222309) do
+  create_table "question_answers", force: :cascade do |t|
+    t.string "question"
+    t.string "answer"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/controllers/ask_controller_test.rb
+++ b/test/controllers/ask_controller_test.rb
@@ -1,24 +1,44 @@
 RSpec.describe AskController, type: :controller do
   describe 'POST #create' do
-    let(:question) { 'This is a test' }
+    describe 'new question' do
+      let(:question) { 'This is a test' }
 
-    before do
-      allow(controller).to receive(:get_new_answer).and_return('Confirmed, this is a test')
+      before do
+        allow(controller).to receive(:get_new_answer).and_return('Confirmed, this is a test')
+      end
+      it 'returns a successful response' do
+        post :create, params: { question: }
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the expected response body' do
+        post :create, params: { question: }
+        expect(JSON.parse(response.body)).to eq({ 'message' => 'Confirmed, this is a test' })
+      end
+
+      it 'calls get_new_answer with the provided question' do
+        expect(controller).to receive(:get_new_answer).with(question)
+        post :create, params: { question: }
+      end
     end
 
-    it 'returns a successful response' do
-      post :create, params: { question: }
-      expect(response).to have_http_status(:created)
-    end
+    describe 'existing question' do
+      let(:question) { 'An existing question' }
 
-    it 'returns the expected response body' do
-      post :create, params: { question: }
-      expect(JSON.parse(response.body)).to eq({ 'message' => 'Confirmed, this is a test' })
-    end
+      it 'returns a successful response' do
+        post :create, params: { question: }
+        expect(response).to have_http_status(:created)
+      end
 
-    it 'calls get_new_answer with the provided question' do
-      expect(controller).to receive(:get_new_answer).with(question)
-      post :create, params: { question: }
+      it 'returns the expected response body' do
+        post :create, params: { question: }
+        expect(JSON.parse(response.body)).to eq({ 'message' => 'An existing answer' })
+      end
+
+      it 'does not call get_new_answer' do
+        expect(controller).not_to receive(:get_new_answer)
+        post :create, params: { question: }
+      end
     end
   end
 end

--- a/test/fixtures/question_answers.yml
+++ b/test/fixtures/question_answers.yml
@@ -1,0 +1,5 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  question: An existing question
+  answer: An existing answer

--- a/test/models/question_answer_test.rb
+++ b/test/models/question_answer_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class QuestionAnswerTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This PR creates a new `QuestionAnswer` model with the required attributes `question` and `answer`, both strings. When hitting the `/ask` endpoint, the question is checked against the db; if it already exists (i.e. the question has been asked before), the saved answer is returned. Otherwise, the new question-answer pair is saved.